### PR TITLE
Add unit tests for github com.github.jbduncan.gradle.refaster.Utils and com.github.jbduncan.collect.testing

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,9 +7,12 @@ repositories {
     mavenCentral()
 }
 
+
 dependencies {
     implementation("commons-io:commons-io:2.6")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:0.0.13")
+    testImplementation("com.google.truth:truth:0.44")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.2")
     // TODO: Use gradle-errorprone-javacplugin-plugin for Java 9+, e.g.
     // implementation("net.ltgt.gradle:gradle-errorprone-javacplugin-plugin:0.2")
 }

--- a/buildSrc/src/test/java/com/github/jbduncan/gradle/refaster/UtilsTest.java
+++ b/buildSrc/src/test/java/com/github/jbduncan/gradle/refaster/UtilsTest.java
@@ -1,0 +1,18 @@
+package com.github.jbduncan.gradle.refaster;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+
+public class UtilsTest {
+
+  @Test
+  public void capitalise() {
+
+    assertThat(Utils.capitalise("")).isEqualTo("");
+    assertThat(Utils.capitalise("a")).isEqualTo("A");
+    assertThat(Utils.capitalise("-")).isEqualTo("-");
+  }
+
+}

--- a/src/test/java/com/github/jbduncan/collect/testing/CollectionFeatureTest.java
+++ b/src/test/java/com/github/jbduncan/collect/testing/CollectionFeatureTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2019 the Jupiter Collection Testers authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jbduncan.collect.testing;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class CollectionFeatureTest {
+
+  @Test
+  public void valueOfInputNotNullOutputIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          CollectionFeature.valueOf("foo");
+        });
+
+    // The method is not expected to return due to exception thrown
+  }
+}

--- a/src/test/java/com/github/jbduncan/collect/testing/CollectionSizeTests.java
+++ b/src/test/java/com/github/jbduncan/collect/testing/CollectionSizeTests.java
@@ -68,4 +68,41 @@ class CollectionSizeTests {
             CollectionSize.SUPPORTS_ONE,
             CollectionSize.SUPPORTS_MULTIPLE);
   }
+
+  @Test
+  public void sizeOutputIllegalStateException() {
+
+    // Arrange
+    final CollectionSize collectionSize = CollectionSize.SUPPORTS_ANY_SIZE;
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          collectionSize.size();
+        });
+
+    // The method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void sizeOutputZero() {
+
+    // Arrange
+    final CollectionSize collectionSize = CollectionSize.SUPPORTS_ZERO;
+
+    // Act and Assert result
+    assertThat(collectionSize.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void valueOfInputNotNullOutputIllegalArgumentException() {
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          CollectionSize.valueOf("a\'b\'c");
+        });
+
+    // The method is not expected to return due to exception thrown
+  }
 }

--- a/src/test/java/com/github/jbduncan/collect/testing/ListContractTests.java
+++ b/src/test/java/com/github/jbduncan/collect/testing/ListContractTests.java
@@ -17,6 +17,7 @@ package com.github.jbduncan.collect.testing;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -361,5 +362,18 @@ class ListContractTests {
         .filter(DynamicTest.class::isInstance)
         .map(DynamicTest.class::cast)
         .collect(toImmutableList());
+  }
+
+  @Test
+  public void newTestListInputNullNullFalseOutputNullPointerException() {
+
+    // Act
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          ListContractHelpers.newTestList(null, null, false);
+        });
+
+    // The method is not expected to return due to exception thrown
   }
 }

--- a/src/test/java/com/github/jbduncan/collect/testing/ListFeatureTests.java
+++ b/src/test/java/com/github/jbduncan/collect/testing/ListFeatureTests.java
@@ -16,6 +16,7 @@
 package com.github.jbduncan.collect.testing;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -95,5 +96,21 @@ class ListFeatureTests {
             ListFeature.SUPPORTS_REMOVE_WITH_INDEX,
             CollectionFeature.SUPPORTS_REMOVE,
             CollectionFeature.SUPPORTS_ITERATOR_REMOVE);
+  }
+
+  @Test
+  public void valueOfInputNotNullOutputIllegalArgumentException() {
+
+    // Arrange
+    final String name = "/";
+
+    // Act
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          ListFeature.valueOf(name);
+        });
+
+    // The method is not expected to return due to exception thrown
   }
 }


### PR DESCRIPTION
## Overview

Thank you for your submission to generate tests using Diffblue Cover. 

One of the new tools introduced into our product is a test ranking system which helps to filter the best tests generated by Diffblue Cover before submitting the PR. We then internally review the other tests to see where we can make improvements. it would be good to get your feedback on these tests. 

Hopefully, these tests will help you detect any regressions caused by future code changes.

If you find these tests useful then I'll be more then happy to refactor them to use Junit 5 which isn't currently supported. 
